### PR TITLE
Enable the new FFI test suites on Power & zLinux

### DIFF
--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/foreign/TestLinker.java
+++ b/test/jdk/java/foreign/TestLinker.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng TestLinker
  */
 

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -23,7 +23,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -295,6 +295,7 @@
  * @test id=VarArgs
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @build NativeTestHelper CallGeneratorHelper
  *
  * @run testng/othervm/native/manual

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -141,8 +141,8 @@ public class TestVarArgs extends CallGeneratorHelper {
              * in which case float must be converted back from double at the same memory
              * address in java on the Big-Endian(BE) platforms such as AIX.
              */
-            if (isAixOS && (layout instanceof ValueLayout) && (((ValueLayout)layout).carrier() == float.class)) {
-                MemorySegment doubleSegmt = MemorySegment.ofAddress(ptr, JAVA_DOUBLE.byteSize(), session);
+            if (isAixOS && (layout instanceof ValueLayout argLayout) && (argLayout.carrier() == float.class)) {
+                MemorySegment doubleSegmt = MemorySegment.ofAddress(ptr.address(), JAVA_DOUBLE.byteSize(), arena.scope());
                 seg.set(JAVA_FLOAT, 0, (float)doubleSegmt.get(JAVA_DOUBLE, 0));
             }
             Object obj = getter.invoke(seg);

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestCaptureCallState
  */
 

--- a/test/jdk/java/foreign/dontrelease/TestDontRelease.java
+++ b/test/jdk/java/foreign/dontrelease/TestDontRelease.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestDontRelease
  */
 

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @requires !vm.musl
  *
  * @library /test/lib

--- a/test/jdk/java/foreign/normalize/TestNormalize.java
+++ b/test/jdk/java/foreign/normalize/TestNormalize.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Xbatch

--- a/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
+++ b/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPassHeapSegment
  */
 

--- a/test/jdk/java/foreign/virtual/TestVirtualCalls.java
+++ b/test/jdk/java/foreign/virtual/TestVirtualCalls.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @library ../
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED


### PR DESCRIPTION
The changes add the Power & zLinux support to
the new FFI test suites introduced in JDK20
plus a few fixes detected in compilation.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>