### PR TITLE
Recognize OpenJ9 flags in openjdk jcl natives

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -123,6 +123,7 @@ endif
 	clean-j9 \
 	clean-j9-dist \
 	clean-openj9-thirdparty-binaries \
+	openj9-config-headers \
 	run-preprocessors-j9 \
 	stage-j9 \
 	#
@@ -142,6 +143,23 @@ define openj9_copy_tree_impl
 		| $(TAR) --extract --directory=$1 -m
 	@$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
+
+ifeq (true,$(OPENJ9_ENABLE_CMAKE))
+  CONFIG_HEADERS := j9cfg.h omr/omrcfg.h
+else
+  CONFIG_HEADERS := include/j9cfg.h omr/include_core/omrcfg.h
+endif
+
+define openj9_config_header_rules
+  openj9-config-headers : $(SUPPORT_OUTPUTDIR)/openj9_include/$(notdir $1)
+
+  $(SUPPORT_OUTPUTDIR)/openj9_include/$(notdir $1) : $1
+	$$(call install-file)
+endef
+
+$(foreach file, \
+	$(CONFIG_HEADERS), \
+	$(eval $(call openj9_config_header_rules, $(OPENJ9_VM_BUILD_DIR)/$(file))))
 
 # openj9_test_image_rules
 # -----------------------

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -170,6 +170,11 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 else
   OPENJ9_VM_BUILD_DIR = $(OUTPUTDIR)/vm
 endif
+
+# Enable use of j9cfg.h in openjdk native code.
+$(foreach var, \
+	CFLAGS_JDKEXE CFLAGS_JDKLIB CXXFLAGS_JDKEXE CXXFLAGS_JDKLIB, \
+	$(eval $(var) += -I$(SUPPORT_OUTPUTDIR)/openj9_include))
 
 J9JCL_SOURCES_DIR      := $(SUPPORT_OUTPUTDIR)/j9jcl
 J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl.done

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -48,6 +48,7 @@ j9vm-build : buildtools-langtools
 	@+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/openssl.gmk
   endif # BUILD_OPENSSL
 	@+$(OPENJ9_MAKE) build-j9
+	@+$(OPENJ9_MAKE) openj9-config-headers
 
 # Modules with content created by j9vm-build:
 OPENJ9_VM_MODULES := \


### PR DESCRIPTION
Recognize `OpenJ9` flags in `openjdk` `jcl` natives

Created `openj9_config_header_rules` and `target openj9-config-headers` which is invoked after `build-j9`, and copy `j9cfg.h` & `omrcfg.h` into `$(SUPPORT_OUTPUTDIR)/openj9_include`;
Added `-I$(SUPPORT_OUTPUTDIR)/openj9_include` for OpenJDK natives.


Cherry-Pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/592
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/596

Signed-off-by: Jason Feng <fengj@ca.ibm.com>