### PR TITLE
Add -Xdump to investigate the LFSingleThreadCachingTest failure

### DIFF
--- a/test/jdk/java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java
+++ b/test/jdk/java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java
@@ -36,7 +36,7 @@
  * @build LambdaFormTestCase
  * @build LFCachingTestCase
  * @build LFSingleThreadCachingTest
- * @run main/othervm -XX:ReservedCodeCacheSize=128m LFSingleThreadCachingTest
+ * @run main/othervm -XX:ReservedCodeCacheSize=128m -Xdump:system+java:events=catch,filter=java/lang/AssertionError LFSingleThreadCachingTest
  */
 
 import java.lang.invoke.MethodHandle;


### PR DESCRIPTION
The `-Xdump` JVM option has been added to the `@run` section in
`LFSingleThreadCachingTest`. This will generate a system and java core
file when the intermittent failure seen in eclipse-openj9/openj9#17312
re-occurs. The core files will be used to investigate the failure.