### PR TITLE
[FFI/Jtreg] Adjust the "%" check in JAVA_DOUBLE on AIX

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -387,7 +387,7 @@ public final class ValueLayouts {
     public static final class OfDoubleImpl extends AbstractValueLayout<OfDoubleImpl> implements ValueLayout.OfDouble {
 
         private OfDoubleImpl(ByteOrder order) {
-            super(double.class, order, 64);
+            super(double.class, order, 64, isAixOS ? 32 : 64, Optional.empty());
         }
 
         private OfDoubleImpl(ByteOrder order, long bitAlignment, Optional<String> name) {
@@ -411,7 +411,7 @@ public final class ValueLayouts {
 
         @Override
         public boolean hasNaturalAlignment() {
-            return isAixOS ? ((bitAlignment() % 32) == 0) : super.hasNaturalAlignment();
+            return isAixOS ? (bitAlignment() == 32) : super.hasNaturalAlignment();
         }
     }
 

--- a/test/jdk/java/foreign/TestValueLayouts.java
+++ b/test/jdk/java/foreign/TestValueLayouts.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @modules java.base/jdk.internal.misc
@@ -38,6 +44,8 @@ import static java.lang.foreign.ValueLayout.*;
 import static org.testng.Assert.*;
 
 public class TestValueLayouts {
+
+    static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 
     @Test
     public void testByte() {
@@ -138,7 +146,7 @@ public class TestValueLayouts {
         assertEquals(layout.carrier(), carrier);
         assertEquals(layout.bitSize(), bitSize);
         assertEquals(layout.order(), ByteOrder.nativeOrder());
-        assertEquals(layout.bitAlignment(), bitAlignment);
+        assertEquals(layout.bitAlignment(), (isAixOS && (layout == JAVA_DOUBLE)) ? 32 : bitAlignment);
         assertTrue(layout.name().isEmpty());
         assertEquals(layout.byteSize(), layout.bitSize() / 8);
         assertEquals(layout.byteAlignment(), layout.bitAlignment() / 8);


### PR DESCRIPTION
The changes adjust the check on `%` in `JAVA_DOUBLE`
on AIX with the natural alignment set to 32bit.

Fixes: #eclipse-openj9/openj9/issues/17443

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
