### PR TITLE
PKCS#12 file-based Keystore support in FIPS mode

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 package com.sun.crypto.provider;
 
@@ -117,7 +122,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             } else if (keyLength < 0) {
                 throw new InvalidKeySpecException("Key length is negative");
             }
-            this.prf = Mac.getInstance(prfAlgo, SunJCE.getInstance());
+            this.prf = Mac.getInstance(prfAlgo);
             this.key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
         } catch (NoSuchAlgorithmException nsae) {
             // not gonna happen; re-throw just in case

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -137,7 +137,8 @@ RestrictedSecurity1.jce.provider.2 = SUN [{CertificateFactory, X.509, Implemente
     {CertStore, com.sun.security.IndexedCollection, ImplementedIn=Software}, \
     {Policy, JavaPolicy, *}, {Configuration, JavaLoginConfig, *}, \
     {CertPathBuilder, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
-    {CertPathValidator, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}]
+    {CertPathValidator, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
+    {KeyStore, PKCS12, *}]
 RestrictedSecurity1.jce.provider.3 = SunEC [{KeyFactory, EC, ImplementedIn=Software: \
     SupportedKeyClasses=java.security.interfaces.ECPublicKey|java.security.interfaces.ECPrivateKey: \
     KeySize=256}, {AlgorithmParameters, EC, *}]

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -33,9 +33,11 @@ package sun.security.pkcs11;
 
 import java.io.*;
 import java.util.*;
+import java.math.BigInteger;
 
 import java.security.*;
 import java.security.interfaces.*;
+import java.security.spec.InvalidKeySpecException;
 import java.util.function.Consumer;
 
 import javax.crypto.BadPaddingException;
@@ -56,7 +58,9 @@ import com.sun.crypto.provider.ChaCha20Poly1305Parameters;
 
 import jdk.internal.misc.InnocuousThread;
 import openj9.internal.security.RestrictedSecurity;
+import sun.security.rsa.RSAUtil.KeyType;
 import sun.security.util.Debug;
+import sun.security.util.ECUtil;
 import sun.security.util.ResourcesMgr;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
 import static sun.security.util.SecurityProviderConstants.getAliases;
@@ -64,6 +68,7 @@ import static sun.security.util.SecurityProviderConstants.getAliases;
 import sun.security.pkcs11.Secmod.*;
 import sun.security.pkcs11.TemplateManager;
 import sun.security.pkcs11.wrapper.*;
+import sun.security.rsa.RSAPrivateCrtKeyImpl;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.*;
 
@@ -527,10 +532,17 @@ public final class SunPKCS11 extends AuthProvider {
         }
     }
 
+    private static BigInteger getBigIntegerOrZero(Map<Long, CK_ATTRIBUTE> ckAttrsMap, long attributeType) {
+        CK_ATTRIBUTE attribute = ckAttrsMap.get(attributeType);
+        return (attribute != null) ? attribute.getBigInteger() : BigInteger.ZERO;
+    }
+
     public long importKey(long hSession, CK_ATTRIBUTE[] attributes) throws PKCS11Exception {
         long keyClass = 0;
         long keyType = 0;
         byte[] keyBytes = null;
+        Map<Long, CK_ATTRIBUTE> ckAttrsMap = new HashMap<>();
+
         // Extract key information.
         for (CK_ATTRIBUTE attr : attributes) {
             if (attr.type == CKA_CLASS) {
@@ -539,12 +551,60 @@ public final class SunPKCS11 extends AuthProvider {
             if (attr.type == CKA_KEY_TYPE) {
                 keyType = attr.getLong();
             }
-            if (attr.type == CKA_VALUE) {
-                keyBytes = attr.getByteArray();
-            }
+            ckAttrsMap.put(attr.type, attr);
         }
 
-        if ((keyClass == CKO_SECRET_KEY) && (keyBytes != null) && (keyBytes.length > 0)) {
+        if (keyClass == CKO_PRIVATE_KEY) {
+            if (keyType == CKK_RSA) {
+                try {
+                    keyBytes = RSAPrivateCrtKeyImpl.newKey(
+                        KeyType.RSA,
+                        null,
+                        getBigIntegerOrZero(ckAttrsMap, CKA_MODULUS),
+                        getBigIntegerOrZero(ckAttrsMap, CKA_PUBLIC_EXPONENT),
+                        getBigIntegerOrZero(ckAttrsMap, CKA_PRIVATE_EXPONENT),
+                        getBigIntegerOrZero(ckAttrsMap, CKA_PRIME_1),
+                        getBigIntegerOrZero(ckAttrsMap, CKA_PRIME_2),
+                        getBigIntegerOrZero(ckAttrsMap, CKA_EXPONENT_1),
+                        getBigIntegerOrZero(ckAttrsMap, CKA_EXPONENT_2),
+                        getBigIntegerOrZero(ckAttrsMap, CKA_COEFFICIENT)
+                    ).getEncoded();
+                } catch (InvalidKeyException e) {
+                    throw new PKCS11Exception(0x00000005L, null);
+                }
+            } else if (keyType == CKK_EC) {
+                CK_ATTRIBUTE ckaECParams = ckAttrsMap.get(CKA_EC_PARAMS);
+                if (ckaECParams == null) {
+                    throw new PKCS11Exception(0x00000005L, "CKA_EC_PARAMS attribute is missing");
+                }
+                try {
+                    keyBytes = ECUtil.generateECPrivateKey(
+                        getBigIntegerOrZero(ckAttrsMap, CKA_VALUE),
+                        ECUtil.getECParameterSpec(
+                            Security.getProvider("SunEC"),
+                            ckaECParams.getByteArray())
+                    ).getEncoded();
+                    // If key is private and of EC type, NSS may require CKA_NETSCAPE_DB
+                    // attribute to unwrap it. Otherwise, C_UnwrapKey will produce an Exception.
+                    if (token.config.getNssNetscapeDbWorkaround() && !ckAttrsMap.containsKey(CKA_NETSCAPE_DB)) {
+                        ckAttrsMap.put(CKA_NETSCAPE_DB, new CK_ATTRIBUTE(CKA_NETSCAPE_DB, BigInteger.ZERO));
+                    }
+                } catch (IOException | InvalidKeySpecException e) {
+                    throw new PKCS11Exception(0x00000005L, null);
+                }
+            }
+        } else if (keyClass == CKO_SECRET_KEY) {
+            CK_ATTRIBUTE ckaValue = ckAttrsMap.get(CKA_VALUE);
+            if (ckaValue == null) {
+                throw new PKCS11Exception(0x00000005L, "CKA_VALUE attribute is missing");
+            }
+            keyBytes = ckaValue.getByteArray();
+        }
+
+        if ((keyBytes != null) && (keyBytes.length > 0)
+            && ((keyClass == CKO_SECRET_KEY)
+                || ((keyClass == CKO_PRIVATE_KEY) && ((keyType == CKK_EC) || (keyType == CKK_RSA))))
+        ) {
             // Generate key used for wrapping and unwrapping of the secret key.
             CK_ATTRIBUTE[] wrapKeyAttributes = token.getAttributes(TemplateManager.O_GENERATE, CKO_SECRET_KEY, CKK_AES, new CK_ATTRIBUTE[] { new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY), new CK_ATTRIBUTE(CKA_VALUE_LEN, 256 >> 3)});
             Session wrapKeyGenSession = token.getObjSession();
@@ -568,7 +628,12 @@ public final class SunPKCS11 extends AuthProvider {
                 byte[] wrappedBytes = wrapCipher.doFinal(keyBytes);
 
                 // Unwrap the secret key.
-                CK_ATTRIBUTE[] unwrapAttributes = token.getAttributes(TemplateManager.O_IMPORT, keyClass, keyType, attributes);
+                // Need additional attributes for EC private key.
+                CK_ATTRIBUTE[] unwrapAttributes = token.getAttributes(
+                    TemplateManager.O_IMPORT,
+                    keyClass,
+                    keyType,
+                    ckAttrsMap.values().toArray(new CK_ATTRIBUTE[ckAttrsMap.size()]));
                 return token.p11.C_UnwrapKey(hSession, wrapMechanism, wrapKeyId, wrappedBytes, unwrapAttributes);
             } catch (PKCS11Exception | NoSuchPaddingException | NoSuchAlgorithmException | BadPaddingException | InvalidAlgorithmParameterException | InvalidKeyException | IllegalBlockSizeException e) {
                 throw new PKCS11Exception(0x00000005L, null);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -149,12 +149,25 @@ public class PKCS11 {
         new HashMap<String,PKCS11>();
 
     static boolean isKey(CK_ATTRIBUTE[] attrs) {
+        boolean isPrivateKey = false;
+        boolean hasKey = false;
+
         for (CK_ATTRIBUTE attr : attrs) {
-            if ((attr.type == CKA_CLASS) && (attr.getLong() == CKO_SECRET_KEY)) {
-                return true;
+            if (attr.type == CKA_CLASS) {
+                if (attr.getLong() == CKO_SECRET_KEY) {
+                    return true;
+                } else if (attr.getLong() == CKO_PRIVATE_KEY) {
+                    isPrivateKey = true;
+                }
+            } else if (attr.type == CKA_KEY_TYPE) {
+                hasKey = true;
+                if (!((attr.getLong() == CKK_RSA) || (attr.getLong() == CKK_EC))) {
+                    isPrivateKey = false;
+                }
             }
         }
-        return false;
+
+        return isPrivateKey && hasKey;
     }
 
     // This is the SunPKCS11 provider instance


### PR DESCRIPTION
This is a backport PR from JDKNext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/573 & https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/606 to JDK20.