### PR TITLE
Revert "Add -Xdump to investigate the LFSingleThreadCachingTest failure"

### DIFF
--- a/test/jdk/java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java
+++ b/test/jdk/java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java
@@ -36,7 +36,7 @@
  * @build LambdaFormTestCase
  * @build LFCachingTestCase
  * @build LFSingleThreadCachingTest
- * @run main/othervm -XX:ReservedCodeCacheSize=128m -Xdump:system+java:events=catch,filter=java/lang/AssertionError LFSingleThreadCachingTest
+ * @run main/othervm -XX:ReservedCodeCacheSize=128m LFSingleThreadCachingTest
  */
 
 import java.lang.invoke.MethodHandle;


### PR DESCRIPTION
Reverts ibmruntimes/openj9-openjdk-jdk20#46.

See https://github.com/eclipse-openj9/openj9/issues/17312#issuecomment-1574016862 for more details.