### PR TITLE
Merge appropriate OpenJ9 changes to the 0.39 branch

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -351,6 +351,9 @@ OPENJ9_VERSION_SCRIPT := \
 $(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h : $(TOPDIR)/closed/openj9_version_info.h.in
 	@$(MKDIR) -p $(@D)
 	@$(SED) $(OPENJ9_VERSION_SCRIPT) > $@ < $<
+	@$(ECHO) "==== $(@F) ===="
+	@$(GREP) define $@
+	@$(ECHO) "===="
 
 # capture values for use with DependOnVariable
 OPENJ9_VERSION_MAP := $(foreach var,$(sort $(OPENJ9_VERSION_VARS)),$(var)='$(value $(var))')

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -2458,13 +2458,13 @@ Java_jdk_crypto_jniprovider_NativeCrypto_ECGenerateKeyPair
 
 cleanup:
     if (NULL != nativeX) {
-        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, 0);
     }
     if (NULL != nativeY) {
-        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, 0);
     }
     if (NULL != nativeS) {
-        (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, 0);
     }
     if (NULL != ctx) {
         (*OSSL_BN_CTX_free)(ctx);
@@ -3049,7 +3049,7 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, salt, nativeSalt, JNI_ABORT);
     }
     if (NULL != nativeKey) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, 0);
     }
 
     return ret;

--- a/src/java.base/aix/classes/sun/nio/ch/Pollset.java
+++ b/src/java.base/aix/classes/sun/nio/ch/Pollset.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, IBM Corp.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.ch;
+
+import java.io.IOException;
+import jdk.internal.misc.Unsafe;
+
+public class Pollset {
+
+    private static final Unsafe unsafe = Unsafe.getUnsafe();
+
+   /**
+     * struct pollfd {
+     *     int fd;
+     *     short events;
+     *     short revents;
+     * }
+     */
+    public static final int SIZEOF_POLLFD    = eventSize();
+    public static final int OFFSETOF_EVENTS  = eventsOffset();
+    public static final int OFFSETOF_REVENTS = reventsOffset();
+    public static final int OFFSETOF_FD      = fdOffset();
+
+    // opcodes
+    public static final int PS_ADD     = 0x0;
+    public static final int PS_MOD     = 0x1;
+    public static final int PS_DELETE  = 0x2;
+
+    // event
+    public static final int PS_POLLPRI = 0x4;
+
+    // revent errcodes
+    public static final char PS_POLLNVAL = 0x8000;
+    public static final char PS_POLLERR  = 0x4000;
+
+    public static final int PS_NO_TIMEOUT = -1;
+
+    /**
+     * Allocates a poll array to handle up to {@code count} events.
+     */
+    public static long allocatePollArray(int count) {
+        return unsafe.allocateMemory(count * SIZEOF_POLLFD);
+    }
+
+    /**
+     * Free a poll array
+     */
+    public static void freePollArray(long address) {
+        unsafe.freeMemory(address);
+    }
+
+    /**
+     * Returns event[i];
+     */
+    public static long getEvent(long address, int i) {
+        return address + (SIZEOF_POLLFD * i);
+    }
+
+    /**
+     * Returns event->fd
+     */
+    public static int getDescriptor(long eventAddress) {
+        return unsafe.getInt(eventAddress + OFFSETOF_FD);
+    }
+
+    /**
+     * Returns event->events
+     */
+    public static int getEvents(long eventAddress) {
+        return unsafe.getChar(eventAddress + OFFSETOF_EVENTS);
+    }
+
+    /**
+     * Returns event->revents
+     */
+    public static char getRevents(long eventAddress) {
+        return unsafe.getChar(eventAddress + OFFSETOF_REVENTS);
+    }
+
+    public static boolean isReventsError(long eventAddress) {
+        char revents = getRevents(eventAddress);
+        return (revents & PS_POLLNVAL) != 0 || (revents & PS_POLLERR) != 0;
+    }
+
+    // -- Native methods --
+    public static native int pollsetCreate() throws IOException;
+    public static native int pollsetCtl(int pollset, int opcode, int fd, int events);
+    public static native int pollsetPoll(int pollset, long pollAddress, int numfds, int timeout)
+        throws IOException;
+    public static native void pollsetDestroy(int pollset);
+    public static native void init();
+    public static native int eventSize();
+    public static native int eventsOffset();
+    public static native int reventsOffset();
+    public static native int fdOffset();
+    public static native void socketpair(int[] sv) throws IOException;
+    public static native void interrupt(int fd) throws IOException;
+    public static native void drain1(int fd) throws IOException;
+    public static native void close0(int fd);
+}

--- a/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
+++ b/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +26,8 @@
 package sun.nio.ch;
 
 import java.io.IOException;
+import java.time.Instant;
+import sun.nio.ch.Pollset;
 
 /**
  * Poller implementation based on the AIX Pollset library.
@@ -32,32 +35,74 @@ import java.io.IOException;
 
 class PollsetPoller extends Poller {
 
+    private static final int MAX_EVENTS_TO_POLL;
+
+    static {
+        Pollset.init(); /* Dynamically loads pollset C functions */
+        MAX_EVENTS_TO_POLL = 512;
+    }
+
+    private final int setid;
+    private final long pollBuffer;
+
     PollsetPoller(boolean read) throws IOException {
         super(read);
+        this.setid = Pollset.pollsetCreate();
+        this.pollBuffer = Pollset.allocatePollArray(MAX_EVENTS_TO_POLL);
     }
 
     @Override
     int fdVal() {
-        // Stub
-        throw new UnsupportedOperationException("Unimplemented on AIX");
+        return setid;
     }
 
     @Override
-    void implRegister(int fdVal) throws IOException {
-        // Stub
-        throw new UnsupportedOperationException("Unimplemented on AIX");
+    void implRegister(int fd) throws IOException {
+        int ret = Pollset.pollsetCtl(setid, Pollset.PS_MOD, fd,
+                          Pollset.PS_POLLPRI | (this.reading() ? Net.POLLIN : Net.POLLOUT));
+        if (ret != 0) {
+            throw new IOException("Unable to register fd " + fd);
+        }
     }
 
     @Override
-    void implDeregister(int fdVal) {
-        // Stub
-        throw new UnsupportedOperationException("Unimplemented on AIX");
+    void implDeregister(int fd) {
+        int ret = Pollset.pollsetCtl(setid, Pollset.PS_DELETE, fd, 0);
+        assert ret == 0;
     }
 
+    /**
+      * Main poll method. The AIX Pollset library does not appear to pick up changes to the pollset
+      * (the set of fds being polled) while blocked on a call to this method. These changes happen
+      * regularly in the poll-loop thread and update thread from Poller.java.
+      * To address this difficulty, we break poll calls into 100ms sub-calls and emulate the timout.
+      */
     @Override
     int poll(int timeout) throws IOException {
-        // Stub
-        throw new UnsupportedOperationException("Unimplemented on AIX");
+        int n;
+        switch (timeout) {
+            case 0:
+                n = pollInner(0);
+                break;
+            case Pollset.PS_NO_TIMEOUT:
+                do { n = pollInner(100); } while (n == 0);
+                break;
+            default:
+                Instant end = Instant.now().plusMillis(timeout);
+                do { n = pollInner(100); } while (n == 0 && Instant.now().isBefore(end));
+                break;
+        }
+        return n;
+    }
+
+    int pollInner(int subInterval) throws IOException {
+        int n = Pollset.pollsetPoll(setid, pollBuffer, MAX_EVENTS_TO_POLL, subInterval);
+        for (int i=0; i<n; i++) {
+            long eventAddress = Pollset.getEvent(pollBuffer, i);
+            int fd = Pollset.getDescriptor(eventAddress);
+            polled(fd);
+        }
+        return n;
     }
 }
 

--- a/src/java.base/aix/native/libnio/ch/Pollset.c
+++ b/src/java.base/aix/native/libnio/ch/Pollset.c
@@ -29,17 +29,16 @@
 #include "jvm.h"
 #include "jlong.h"
 
-#include "sun_nio_ch_AixPollPort.h"
+#include "sun_nio_ch_Pollset.h"
 
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <poll.h>
-#include <sys/pollset.h>
-#include <fcntl.h>
-#include <stddef.h>
 #include <dlfcn.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/pollset.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 /* Initially copied from src/solaris/native/sun/nio/ch/nio_util.h */
 #define RESTARTABLE(_cmd, _result) do { \
@@ -58,7 +57,7 @@ static pollset_ctl_func* _pollset_ctl = NULL;
 static pollset_poll_func* _pollset_poll = NULL;
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_AixPollPort_init(JNIEnv* env, jclass this) {
+Java_sun_nio_ch_Pollset_init(JNIEnv* env, jclass this) {
     _pollset_create = (pollset_create_func*) dlsym(RTLD_DEFAULT, "pollset_create");
     _pollset_destroy = (pollset_destroy_func*) dlsym(RTLD_DEFAULT, "pollset_destroy");
     _pollset_ctl = (pollset_ctl_func*) dlsym(RTLD_DEFAULT, "pollset_ctl");
@@ -70,27 +69,27 @@ Java_sun_nio_ch_AixPollPort_init(JNIEnv* env, jclass this) {
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_ch_AixPollPort_eventSize(JNIEnv* env, jclass this) {
+Java_sun_nio_ch_Pollset_eventSize(JNIEnv* env, jclass this) {
     return sizeof(struct pollfd);
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_ch_AixPollPort_eventsOffset(JNIEnv* env, jclass this) {
+Java_sun_nio_ch_Pollset_eventsOffset(JNIEnv* env, jclass this) {
     return offsetof(struct pollfd, events);
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_ch_AixPollPort_reventsOffset(JNIEnv* env, jclass this) {
+Java_sun_nio_ch_Pollset_reventsOffset(JNIEnv* env, jclass this) {
     return offsetof(struct pollfd, revents);
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_ch_AixPollPort_fdOffset(JNIEnv* env, jclass this) {
+Java_sun_nio_ch_Pollset_fdOffset(JNIEnv* env, jclass this) {
     return offsetof(struct pollfd, fd);
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_ch_AixPollPort_pollsetCreate(JNIEnv *env, jclass c) {
+Java_sun_nio_ch_Pollset_pollsetCreate(JNIEnv *env, jclass c) {
     /* pollset_create can take the maximum number of fds, but we
      * cannot predict this number so we leave it at OPEN_MAX. */
     pollset_t ps = _pollset_create(-1);
@@ -101,7 +100,7 @@ Java_sun_nio_ch_AixPollPort_pollsetCreate(JNIEnv *env, jclass c) {
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_ch_AixPollPort_pollsetCtl(JNIEnv *env, jclass c, jint ps,
+Java_sun_nio_ch_Pollset_pollsetCtl(JNIEnv *env, jclass c, jint ps,
                                        jint opcode, jint fd, jint events) {
     struct poll_ctl event;
     int res;
@@ -116,26 +115,27 @@ Java_sun_nio_ch_AixPollPort_pollsetCtl(JNIEnv *env, jclass c, jint ps,
 }
 
 JNIEXPORT jint JNICALL
-Java_sun_nio_ch_AixPollPort_pollsetPoll(JNIEnv *env, jclass c,
-                                        jint ps, jlong address, jint numfds) {
+Java_sun_nio_ch_Pollset_pollsetPoll(JNIEnv *env, jclass c,
+                                        jint ps, jlong address, jint numfds, jint timeout) {
     struct pollfd *events = jlong_to_ptr(address);
     int res;
 
-    RESTARTABLE(_pollset_poll(ps, events, numfds, -1), res);
+    RESTARTABLE(_pollset_poll(ps, events, numfds, timeout), res);
     if (res < 0) {
+        perror("pollset_poll failed");
         JNU_ThrowIOExceptionWithLastError(env, "pollset_poll failed");
     }
     return res;
 }
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_AixPollPort_pollsetDestroy(JNIEnv *env, jclass c, jint ps) {
+Java_sun_nio_ch_Pollset_pollsetDestroy(JNIEnv *env, jclass c, jint ps) {
     int res;
     RESTARTABLE(_pollset_destroy((pollset_t)ps), res);
 }
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_AixPollPort_socketpair(JNIEnv* env, jclass clazz, jintArray sv) {
+Java_sun_nio_ch_Pollset_socketpair(JNIEnv* env, jclass clazz, jintArray sv) {
     int sp[2];
     if (socketpair(PF_UNIX, SOCK_STREAM, 0, sp) == -1) {
         JNU_ThrowIOExceptionWithLastError(env, "socketpair failed");
@@ -148,7 +148,7 @@ Java_sun_nio_ch_AixPollPort_socketpair(JNIEnv* env, jclass clazz, jintArray sv) 
 }
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_AixPollPort_interrupt(JNIEnv *env, jclass c, jint fd) {
+Java_sun_nio_ch_Pollset_interrupt(JNIEnv *env, jclass c, jint fd) {
     int res;
     int buf[1];
     buf[0] = 1;
@@ -159,7 +159,7 @@ Java_sun_nio_ch_AixPollPort_interrupt(JNIEnv *env, jclass c, jint fd) {
 }
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_AixPollPort_drain1(JNIEnv *env, jclass cl, jint fd) {
+Java_sun_nio_ch_Pollset_drain1(JNIEnv *env, jclass cl, jint fd) {
     int res;
     char buf[1];
     RESTARTABLE(read(fd, buf, 1), res);
@@ -169,7 +169,7 @@ Java_sun_nio_ch_AixPollPort_drain1(JNIEnv *env, jclass cl, jint fd) {
 }
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_AixPollPort_close0(JNIEnv *env, jclass c, jint fd) {
+Java_sun_nio_ch_Pollset_close0(JNIEnv *env, jclass c, jint fd) {
     int res;
     RESTARTABLE(close(fd), res);
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -387,7 +387,7 @@ public final class ValueLayouts {
     public static final class OfDoubleImpl extends AbstractValueLayout<OfDoubleImpl> implements ValueLayout.OfDouble {
 
         private OfDoubleImpl(ByteOrder order) {
-            super(double.class, order, 64);
+            super(double.class, order, 64, isAixOS ? 32 : 64, Optional.empty());
         }
 
         private OfDoubleImpl(ByteOrder order, long bitAlignment, Optional<String> name) {
@@ -411,7 +411,7 @@ public final class ValueLayouts {
 
         @Override
         public boolean hasNaturalAlignment() {
-            return isAixOS ? ((bitAlignment() % 32) == 0) : super.hasNaturalAlignment();
+            return isAixOS ? (bitAlignment() == 32) : super.hasNaturalAlignment();
         }
     }
 

--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,9 +97,9 @@ public abstract class Poller {
      */
     private void poll(int fdVal, long nanos, BooleanSupplier supplier) throws IOException {
         if (USE_DIRECT_REGISTER) {
-            poll1(fdVal, nanos, supplier);
+            pollDirect(fdVal, nanos, supplier);
         } else {
-            poll2(fdVal, nanos, supplier);
+            pollIndirect(fdVal, nanos, supplier);
         }
     }
 
@@ -107,7 +107,7 @@ public abstract class Poller {
      * Parks the current thread until a file descriptor is ready. This implementation
      * registers the file descriptor, then parks until the file descriptor is polled.
      */
-    private void poll1(int fdVal, long nanos, BooleanSupplier supplier) throws IOException {
+    private void pollDirect(int fdVal, long nanos, BooleanSupplier supplier) throws IOException {
         register(fdVal);
         try {
             boolean isOpen = supplier.getAsBoolean();
@@ -128,7 +128,7 @@ public abstract class Poller {
      * queues the file descriptor to the update thread, then parks until the file
      * descriptor is polled.
      */
-    private void poll2(int fdVal, long nanos, BooleanSupplier supplier) {
+    private void pollIndirect(int fdVal, long nanos, BooleanSupplier supplier) {
         Request request = registerAsync(fdVal);
         try {
             boolean isOpen = supplier.getAsBoolean();

--- a/test/jdk/java/foreign/TestValueLayouts.java
+++ b/test/jdk/java/foreign/TestValueLayouts.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @modules java.base/jdk.internal.misc
@@ -38,6 +44,8 @@ import static java.lang.foreign.ValueLayout.*;
 import static org.testng.Assert.*;
 
 public class TestValueLayouts {
+
+    static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 
     @Test
     public void testByte() {
@@ -138,7 +146,7 @@ public class TestValueLayouts {
         assertEquals(layout.carrier(), carrier);
         assertEquals(layout.bitSize(), bitSize);
         assertEquals(layout.order(), ByteOrder.nativeOrder());
-        assertEquals(layout.bitAlignment(), bitAlignment);
+        assertEquals(layout.bitAlignment(), (isAixOS && (layout == JAVA_DOUBLE)) ? 32 : bitAlignment);
         assertTrue(layout.name().isEmpty());
         assertEquals(layout.byteSize(), layout.bitSize() / 8);
         assertEquals(layout.byteAlignment(), layout.bitAlignment() / 8);


### PR DESCRIPTION
Cherry picked the following for 0.39.

https://github.com/ibmruntimes/openj9-openjdk-jdk20/pull/48 - "Show macro definitions generated in openj9_version_info.h"
https://github.com/ibmruntimes/openj9-openjdk-jdk20/pull/51 - "Fix mode of ReleasePrimitiveArrayCritical to ensure copying of data"
https://github.com/ibmruntimes/openj9-openjdk-jdk20/pull/49 - "[FFI/Jtreg] Adjust the "%" check in JAVA_DOUBLE on AIX"
https://github.com/ibmruntimes/openj9-openjdk-jdk20/pull/57 - "Port 8286597: Implement PollerProvider on AIX"