### PR TITLE
Add back the provider argument while getting MAC instance

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -49,6 +49,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import jdk.internal.ref.CleanerFactory;
 
+import openj9.internal.security.RestrictedSecurity;
+
 /**
  * This class represents a PBE key derived using PBKDF2 defined
  * in PKCS#5 v2.0. meaning that
@@ -122,7 +124,11 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             } else if (keyLength < 0) {
                 throw new InvalidKeySpecException("Key length is negative");
             }
-            this.prf = Mac.getInstance(prfAlgo);
+            if (RestrictedSecurity.isFIPSEnabled()) {
+                this.prf = Mac.getInstance(prfAlgo);
+            } else {
+                this.prf = Mac.getInstance(prfAlgo, SunJCE.getInstance());
+            }
             this.key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
         } catch (NoSuchAlgorithmException nsae) {
             // not gonna happen; re-throw just in case


### PR DESCRIPTION
This is a backport PR from JDKNext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/612 to JDK20.